### PR TITLE
Fix underfluid parser defaulting to water if the genFluid json is valid,...

### DIFF
--- a/src/main/java/cofh/core/world/feature/UnderfluidParser.java
+++ b/src/main/java/cofh/core/world/feature/UnderfluidParser.java
@@ -37,7 +37,7 @@ public class UnderfluidParser extends UniformParser {
 		int[] fluidList = null;
 		l: if (genObject.has("genFluid")) {
 			ArrayList<DungeonMob> list = new ArrayList<DungeonMob>();
-			if (FeatureParser.parseWeightedStringList(genObject.get("genFluid"), list)) {
+			if (!FeatureParser.parseWeightedStringList(genObject.get("genFluid"), list)) {
 				break l;
 			}
 			water = false;


### PR DESCRIPTION
... rather than invalid.

I've tested with a custom generator that should generate ores under lava, but they generates under water instead.  The logic of this statement is to break from continuing to build the list of fluids if the json is invalid and use water as a default.  parseWeightedStringList returns true if valid, so it should not break if true.
