### PR TITLE
Fixed typo in BucketHandler

### DIFF
--- a/src/main/java/cofh/core/util/fluid/BucketHandler.java
+++ b/src/main/java/cofh/core/util/fluid/BucketHandler.java
@@ -46,7 +46,7 @@ public class BucketHandler {
 	@SubscribeEvent(priority = EventPriority.HIGHEST)
 	public void onBucketFill(FillBucketEvent event) {
 
-		if (ServerHelper.isClientWorld(event.world) | event.result != null || event.getResult() != Result.DEFAULT) {
+		if (ServerHelper.isClientWorld(event.world) || event.result != null || event.getResult() != Result.DEFAULT) {
 			return;
 		}
 		ItemStack current = event.current;


### PR DESCRIPTION
`|` should be `||`

Yep, https://github.com/GrowthcraftCE/Growthcraft-1.7/issues/365#issuecomment-218225895

I've also updated our bucket handler to use a similar condition (now that I've seen this) as well
