### PR TITLE
Fix future issue with identifier name

### DIFF
--- a/src/main/java/cofh/core/RegistryEnderAttuned.java
+++ b/src/main/java/cofh/core/RegistryEnderAttuned.java
@@ -35,18 +35,18 @@ public class RegistryEnderAttuned {
 		clientChannels = new ClientEnderChannelRegistry() {
 
 			@Override
-			public String setFrequency(String _, int freq, String name) {
+			public String setFrequency(String string, int freq, String name) {
 
-				if (_ != dummy) {
+				if (string != dummy) {
 					PacketHandler.sendToServer(new Packet(hostedChannel, freq, name));
 				}
 				return super.setFrequency(hostedChannel, freq, name);
 			}
 
 			@Override
-			public String removeFrequency(String _, int freq) {
+			public String removeFrequency(String string, int freq) {
 
-				if (_ != dummy) {
+				if (string != dummy) {
 					PacketHandler.sendToServer(new Packet(hostedChannel, freq));
 				}
 				return super.removeFrequency(hostedChannel, freq);


### PR DESCRIPTION
In Java 9, the underscore is a keyword and cannot be used as an identifier name.
