### PR TITLE
fix clear fluid stakc bug when put into inv

### DIFF
--- a/src/main/java/cofh/core/util/crafting/RecipeShapelessOreFluid.java
+++ b/src/main/java/cofh/core/util/crafting/RecipeShapelessOreFluid.java
@@ -94,7 +94,7 @@ public class RecipeShapelessOreFluid extends ShapelessOreRecipe {
 						ItemStack requiredStack = (ItemStack) aRequired;
 						if (requiredStack.getItem() == ForgeModContainer.getInstance().universalBucket) {
 							FluidStack fluidStack = Validate.notNull(FluidUtil.getFluidContained(requiredStack));
-							IFluidHandler fluidHandler = FluidUtil.getFluidHandler(stackInSlot);
+							IFluidHandler fluidHandler = FluidUtil.getFluidHandler(stackInSlot.copy());
 							if (fluidHandler != null) {
 								if (fluidStack.isFluidStackIdentical(fluidHandler.drain(Fluid.BUCKET_VOLUME, false))) {
 									match = true;


### PR DESCRIPTION
this bug can reproduce by placing ic2 cell to craft inv at slot 0,bug cause by line 99,fluidHandler.drain