### PR TITLE
Updated overlooked Forge version reference and restored ability to disable particles.

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 # Minecraft Version
 mc_version=1.12.2
-forge_version=14.23.3.2655
+forge_version=14.23.4.2739
 mappings=snapshot_20171003
 
 # Dependencies

--- a/src/main/java/cofh/CoFHCore.java
+++ b/src/main/java/cofh/CoFHCore.java
@@ -39,7 +39,7 @@ public class CoFHCore {
 	public static final String MOD_ID = "cofhcore";
 	public static final String MOD_NAME = "CoFH Core";
 
-	public static final String VERSION = "4.5.2";
+	public static final String VERSION = "4.5.3";
 	public static final String VERSION_MAX = "4.6.0";
 	public static final String VERSION_GROUP = "required-after:" + MOD_ID + "@[" + VERSION + "," + VERSION_MAX + ");";
 	public static final String UPDATE_URL = "https://raw.github.com/cofh/version/master/" + MOD_ID + "_update.json";

--- a/src/main/java/cofh/core/fluid/BlockFluidCore.java
+++ b/src/main/java/cofh/core/fluid/BlockFluidCore.java
@@ -128,11 +128,6 @@ public abstract class BlockFluidCore extends BlockFluidClassic implements IIniti
 	}
 
 	/* ACCESSORS */
-	public int getDensity() {
-
-		return density;
-	}
-
 	public int getDensityDir() {
 
 		return densityDir;

--- a/src/main/java/cofh/core/init/CoreProps.java
+++ b/src/main/java/cofh/core/init/CoreProps.java
@@ -136,8 +136,8 @@ public class CoreProps {
 	}
 
 	/* FORGE INFO */
-	private static final String BUILD = "2655";
-	private static final String FORGE_REQ = "14.23.3." + BUILD;
+	private static final String BUILD = "2739";
+	private static final String FORGE_REQ = "14.23.4." + BUILD;
 	private static final String FORGE_REQ_MAX = "15.0.0.0";
 
 	public static final String FORGE_DEP = "required-after:forge@[" + FORGE_REQ + "," + FORGE_REQ_MAX + ");";

--- a/src/main/java/cofh/core/proxy/ProxyClient.java
+++ b/src/main/java/cofh/core/proxy/ProxyClient.java
@@ -45,17 +45,17 @@ public class ProxyClient extends Proxy {
 
 		Minecraft.memoryReserve = null;
 		ShaderHelper.initShaders();
-
-		if (CoreProps.disableParticles) {
-			CoFHCore.LOG.info("Replacing EffectRenderer - Particles have been disabled.");
-			Minecraft.getMinecraft().effectRenderer = new CustomEffectRenderer();
-		}
 	}
 
 	@Override
 	public void initialize(FMLInitializationEvent event) {
 
 		super.initialize(event);
+
+		if (CoreProps.disableParticles) {
+			CoFHCore.LOG.info("Replacing EffectRenderer - Particles have been disabled.");
+			Minecraft.getMinecraft().effectRenderer = new CustomEffectRenderer();
+		}
 	}
 
 	@Override


### PR DESCRIPTION
I only tested in 1.12.2-14.23.4.2703 and 1.12.2-14.23.4.2739, so I don't know at what version overwriting Minecraft#effectRenderer stopped working when done in preInit.