### PR TITLE
Add partitioned block states

### DIFF
--- a/src/main/java/cofh/core/block/AdaptedProperty.java
+++ b/src/main/java/cofh/core/block/AdaptedProperty.java
@@ -1,0 +1,26 @@
+package cofh.core.block;
+
+import net.minecraft.block.properties.IProperty;
+import net.minecraftforge.common.property.Properties;
+
+/**
+ * A wrapper around PropertyAdapter that exposes the original property.
+ *
+ * @author amadornes
+ */
+public class AdaptedProperty<V extends Comparable<V>> extends Properties.PropertyAdapter<V> {
+
+	private final IProperty<V> parent;
+
+	public AdaptedProperty(IProperty<V> parent) {
+
+		super(parent);
+		this.parent = parent;
+	}
+
+	public IProperty<V> getActualProperty() {
+
+		return parent;
+	}
+
+}

--- a/src/main/java/cofh/core/block/PartitionedBlockState.java
+++ b/src/main/java/cofh/core/block/PartitionedBlockState.java
@@ -1,0 +1,139 @@
+package cofh.core.block;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.state.BlockStateContainer;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.property.ExtendedBlockState;
+import net.minecraftforge.common.property.IUnlistedProperty;
+import scala.actors.threadpool.Arrays;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A modified version of ExtendedBlockState with support for property partitions.<br/>
+ * These allow for the declaration of properties that are baked independently from the rest of the model and composed in real time.
+ *
+ * @author amadornes
+ */
+public class PartitionedBlockState extends ExtendedBlockState {
+
+	private final Partition[] partitions;
+
+	private PartitionedBlockState(Block block, IProperty<?>[] properties, IUnlistedProperty<?>[] unlistedProperties, Partition[] partitions) {
+
+		super(block, properties, unlistedProperties);
+		this.partitions = partitions;
+	}
+
+	public Partition[] getPartitions() {
+
+		return partitions;
+	}
+
+	public static class Partition {
+
+		private final AdaptedProperty<?>[] properties;
+
+		private final ResourceLocation name;
+		private final BlockStateContainer partitionContainer;
+
+		private Partition(Block block, ResourceLocation name, AdaptedProperty<?>[] properties) {
+
+			this.properties = properties;
+			this.name = name;
+
+			IProperty<?>[] blockProperties = new IProperty[properties.length];
+			for (int i = 0; i < properties.length; i++) {
+				blockProperties[i] = properties[i].getActualProperty();
+			}
+			this.partitionContainer = new BlockStateContainer(block, blockProperties);
+		}
+
+		public AdaptedProperty[] getProperties() {
+
+			return properties;
+		}
+
+		public ResourceLocation getName() {
+
+			return name;
+		}
+
+		public BlockStateContainer getPartitionContainer() {
+
+			return partitionContainer;
+		}
+
+	}
+
+	public static class Builder {
+
+		private final Block block;
+		private final Set<String> propertyNames = new HashSet<>();
+		// Only really using a list here because Forge does. I don't think ordering matters at all, but just in case...
+		private final List<IProperty<?>> listed = new ArrayList<>();
+		private final Set<IUnlistedProperty<?>> unlisted = new HashSet<>();
+		private final List<Partition> partitions = new ArrayList<>();
+
+		public Builder(Block block) {
+
+			this.block = block;
+		}
+
+		public Builder add(IProperty<?>... props) {
+
+			for (IProperty<?> prop : props) {
+				if (propertyNames.add(prop.getName())) {
+					listed.add(prop);
+				} else {
+					throw new IllegalArgumentException("Attempted to add an already existing block property: " + prop.getName());
+				}
+			}
+			return this;
+		}
+
+		public Builder add(IUnlistedProperty<?>... props) {
+
+			unlisted.addAll(Arrays.asList(props));
+			return this;
+		}
+
+		public Builder addPartition(String domain, String name, AdaptedProperty<?>... props) {
+
+			return addPartition(new ResourceLocation(domain, name), props);
+		}
+
+		public Builder addPartition(ResourceLocation name, AdaptedProperty<?>... props) {
+
+			for (AdaptedProperty<?> prop : props) {
+				if (propertyNames.contains(prop.getName())) {
+					throw new IllegalArgumentException("Attempted to add an already existing block property to a partition: " + prop.getName());
+				}
+			}
+			for (AdaptedProperty<?> prop : props) {
+				propertyNames.add(prop.getName());
+				unlisted.add(prop);
+			}
+			partitions.add(new Partition(block, name, props));
+			return this;
+		}
+
+		public BlockStateContainer build() {
+
+			IProperty<?>[] listed = this.listed.toArray(new IProperty[0]);
+			if (partitions.isEmpty()) {
+				IUnlistedProperty<?>[] unlisted = this.unlisted.toArray(new IUnlistedProperty[0]);
+				return new BlockStateContainer.Builder(block).add(listed).add(unlisted).build();
+			}
+			IUnlistedProperty<?>[] unlisted = this.unlisted.toArray(new IUnlistedProperty[0]);
+			Partition[] partitions = this.partitions.toArray(new Partition[0]);
+			return new PartitionedBlockState(block, listed, unlisted, partitions);
+		}
+
+	}
+
+}

--- a/src/main/java/cofh/core/proxy/EventHandlerPartitionedModel.java
+++ b/src/main/java/cofh/core/proxy/EventHandlerPartitionedModel.java
@@ -1,0 +1,68 @@
+package cofh.core.proxy;
+
+import cofh.core.block.PartitionedBlockState;
+import cofh.core.render.model.PartitionedBakedModel;
+import cofh.core.render.model.PartitionedStateMapper;
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.renderer.block.model.IBakedModel;
+import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.client.renderer.block.statemap.DefaultStateMapper;
+import net.minecraft.client.renderer.block.statemap.StateMapperBase;
+import net.minecraftforge.client.event.ModelBakeEvent;
+import net.minecraftforge.client.event.ModelRegistryEvent;
+import net.minecraftforge.client.model.ModelLoader;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import java.util.Collection;
+
+/**
+ * A handler for partitioned block model lifecycle events.
+ *
+ * @author amadornes
+ */
+@SideOnly(Side.CLIENT)
+public final class EventHandlerPartitionedModel {
+
+	public static final EventHandlerPartitionedModel INSTANCE = new EventHandlerPartitionedModel();
+
+	/**
+	 * Finds all blocks with partitioned state and replaces their state mapper with one that also loads partition models.
+	 */
+	@SubscribeEvent
+	public void onModelRegistryReady(ModelRegistryEvent event) {
+
+		for (Block block : ForgeRegistries.BLOCKS.getValuesCollection()) {
+			if (block.getBlockState() instanceof PartitionedBlockState) {
+				PartitionedBlockState pbs = (PartitionedBlockState) block.getBlockState();
+				ModelLoader.setCustomStateMapper(block, new PartitionedStateMapper(pbs));
+			}
+		}
+	}
+
+	/**
+	 * Finds all the blocks with partitioned state and wraps all their models to add those partitions.
+	 */
+	@SubscribeEvent
+	public void onModelBaked(ModelBakeEvent event) {
+
+		// Dummy state mapper just so we can use the unified getPropertyString method
+		DefaultStateMapper stateMapper = new DefaultStateMapper();
+
+		for (Block block : ForgeRegistries.BLOCKS.getValuesCollection()) {
+			if (block.getBlockState() instanceof PartitionedBlockState) {
+				PartitionedBlockState pbs = (PartitionedBlockState) block.getBlockState();
+				for (IBlockState state : pbs.getValidStates()) {
+					String propertyString = stateMapper.getPropertyString(state.getProperties());
+					ModelResourceLocation location = new ModelResourceLocation(block.getRegistryName(), propertyString);
+					IBakedModel model = event.getModelRegistry().getObject(location);
+					event.getModelRegistry().putObject(location, new PartitionedBakedModel(model, pbs.getPartitions()));
+				}
+			}
+		}
+	}
+
+}

--- a/src/main/java/cofh/core/proxy/ProxyClient.java
+++ b/src/main/java/cofh/core/proxy/ProxyClient.java
@@ -42,6 +42,7 @@ public class ProxyClient extends Proxy {
 
 		MinecraftForge.EVENT_BUS.register(EventHandlerClient.INSTANCE);
 		MinecraftForge.EVENT_BUS.register(EventHandlerRender.INSTANCE);
+		MinecraftForge.EVENT_BUS.register(EventHandlerPartitionedModel.INSTANCE);
 
 		Minecraft.memoryReserve = null;
 		ShaderHelper.initShaders();

--- a/src/main/java/cofh/core/render/model/PartitionedBakedModel.java
+++ b/src/main/java/cofh/core/render/model/PartitionedBakedModel.java
@@ -1,0 +1,119 @@
+package cofh.core.render.model;
+
+import cofh.core.block.AdaptedProperty;
+import cofh.core.block.PartitionedBlockState;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.BlockModelShapes;
+import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.client.renderer.block.model.IBakedModel;
+import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
+import net.minecraft.client.renderer.block.model.ItemOverrideList;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.property.IExtendedBlockState;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import org.apache.commons.lang3.tuple.Pair;
+
+import javax.annotation.Nullable;
+import javax.vecmath.Matrix4f;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A model extending another that merges property partitions into its quads on request.
+ *
+ * @author amadornes
+ */
+@SideOnly(Side.CLIENT)
+public class PartitionedBakedModel implements IBakedModel {
+
+	private final IBakedModel parent;
+	private final PartitionedBlockState.Partition[] partitions;
+
+	public PartitionedBakedModel(IBakedModel parent, PartitionedBlockState.Partition[] partitions) {
+
+		this.parent = parent;
+		this.partitions = partitions;
+	}
+
+	@Override
+	public List<BakedQuad> getQuads(@Nullable IBlockState state, @Nullable EnumFacing side, long rand) {
+
+		List<BakedQuad> quads = new ArrayList<>(parent.getQuads(state, side, rand));
+		BlockModelShapes bms = Minecraft.getMinecraft().getBlockRendererDispatcher().getBlockModelShapes();
+		for (PartitionedBlockState.Partition partition : partitions) {
+			IBlockState partitionState = partition.getPartitionContainer().getBaseState();
+			if (state instanceof IExtendedBlockState) {
+				IExtendedBlockState extendedState = (IExtendedBlockState) state;
+				for (AdaptedProperty<?> property : partition.getProperties()) {
+					partitionState = with(partitionState, extendedState, property);
+				}
+			}
+			IBakedModel partitionModel = bms.getModelForState(partitionState);
+			quads.addAll(partitionModel.getQuads(partitionState, side, rand));
+		}
+		return quads;
+	}
+
+	// Dirty little hack to avoid quite a few ugly raw casts
+	private <V extends Comparable<V>> IBlockState with(IBlockState dst, IExtendedBlockState src, AdaptedProperty<V> prop) {
+
+		return dst.withProperty(prop.getActualProperty(), src.getValue(prop));
+	}
+
+	@Override
+	public boolean isAmbientOcclusion() {
+
+		return parent.isAmbientOcclusion();
+	}
+
+	@Override
+	public boolean isGui3d() {
+
+		return parent.isGui3d();
+	}
+
+	@Override
+	public boolean isBuiltInRenderer() {
+
+		return parent.isBuiltInRenderer();
+	}
+
+	@Override
+	public TextureAtlasSprite getParticleTexture() {
+
+		return parent.getParticleTexture();
+	}
+
+	@Override
+	@Deprecated
+	public ItemCameraTransforms getItemCameraTransforms() {
+
+		return parent.getItemCameraTransforms();
+	}
+
+	@Override
+	public ItemOverrideList getOverrides() {
+
+		return parent.getOverrides();
+	}
+
+	@Override
+	public boolean isAmbientOcclusion(IBlockState state) {
+
+		return parent.isAmbientOcclusion(state);
+	}
+
+	@Override
+	public Pair<? extends IBakedModel, Matrix4f> handlePerspective(ItemCameraTransforms.TransformType cameraTransformType) {
+
+		Pair<? extends IBakedModel, Matrix4f> pair = parent.handlePerspective(cameraTransformType);
+		if (pair.getLeft() != parent) {
+			return pair;
+		}
+		return Pair.of(this, pair.getRight());
+	}
+
+}

--- a/src/main/java/cofh/core/render/model/PartitionedStateMapper.java
+++ b/src/main/java/cofh/core/render/model/PartitionedStateMapper.java
@@ -1,0 +1,48 @@
+package cofh.core.render.model;
+
+import cofh.core.block.PartitionedBlockState;
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.client.renderer.block.statemap.DefaultStateMapper;
+import net.minecraft.util.ResourceLocation;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+/**
+ * An IStateMapper implementation that also registers all partition models to be loaded.
+ *
+ * @author amadornes
+ */
+public class PartitionedStateMapper extends DefaultStateMapper {
+
+	private final PartitionedBlockState state;
+
+	public PartitionedStateMapper(PartitionedBlockState state) {
+
+		this.state = state;
+	}
+
+	@Override
+	public Map<IBlockState, ModelResourceLocation> putStateModelLocations(Block block) {
+
+		if (block != state.getBlock()) {
+			return super.putStateModelLocations(block); // If we somehow end up here, let's just play it safe
+		}
+
+		Map<IBlockState, ModelResourceLocation> map = new IdentityHashMap<>(super.putStateModelLocations(block));
+		for (PartitionedBlockState.Partition partition : state.getPartitions()) {
+			ResourceLocation name = partition.getName();
+			if (name == null) {
+				name = block.getRegistryName();
+			}
+			for (IBlockState state : partition.getPartitionContainer().getValidStates()) {
+				String propertyString = getPropertyString(state.getProperties());
+				map.put(state, new ModelResourceLocation(name, propertyString));
+			}
+		}
+		return map;
+	}
+
+}


### PR DESCRIPTION
As per @KingLemming's request, here's a simple system to partition blockstates into groups of properties and compose them at runtime, reducing the amount of total blockstates needed for any given block, especially those with high permutation counts like machines.

**Usage:**  
Instead of using `BlockStateContainer.Builder` to create a blockstate container, use `PartitionedBlockState.Builder`, and register your partitions via `.addPartition(name, props)`.  
Partition properties can then be set in the block's `getExtendedState(...)` method.

Each partition should have its own blockstate file (name passed on registration), which declares only the partition's properties and no others.  
The block's main blockstate file should not specify partition properties either.

Everything else is handled automatically via the two built-in model lifecycle event handlers.