### PR TITLE
Update ItemToolCore.java

### DIFF
--- a/src/main/java/cofh/core/item/tool/ItemToolCore.java
+++ b/src/main/java/cofh/core/item/tool/ItemToolCore.java
@@ -234,7 +234,7 @@ public abstract class ItemToolCore extends ItemTool {
 	@Override
 	public float getDestroySpeed(ItemStack stack, IBlockState state) {
 
-		return (getEffectiveMaterials(stack).contains(state.getMaterial()) || getEffectiveBlocks(stack).contains(state)) ? getEfficiency(stack) : 1.0F;
+		return (getEffectiveMaterials(stack).contains(state.getMaterial()) || getEffectiveBlocks(stack).contains(state.getBlock())) ? getEfficiency(stack) : 1.0F;
 	}
 
 	@Override


### PR DESCRIPTION
Small fix for block breaking speed.

I realize this is probably too minor to make it into the 1.12 builds, and isn't really worth jumping into Discord to mention, but I wanted you to be aware of it for the 1.14+ updates (since the issues tab is missing instead of read-only, I can't tell whether it was filed as a bug before). I mainly noticed this when trying to break rails with a flux-infused pickaxe, which was no faster than bare hands even when enchanted with Efficiency V (players who use Railcraft might not even notice that, since iirc that mod adds a crowbar to break rails with instead).